### PR TITLE
vocab mapping

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod cxx;
 pub mod headers;
+mod mapping;
 pub(crate) mod model;
 pub mod reader;
 

--- a/src/mapping/mod.rs
+++ b/src/mapping/mod.rs
@@ -1,0 +1,86 @@
+use std::collections::HashMap;
+
+pub trait BidirectionalMapping<INDEX, VALUE> {
+    fn insert_or_get_index(&mut self, value: VALUE) -> INDEX;
+    fn get_index(&self, value: &VALUE) -> Option<&INDEX>;
+    fn get_value(&mut self, index: INDEX) -> Option<&VALUE>;
+    fn len(&self) -> usize;
+}
+#[derive(Debug)]
+pub enum Mappings {
+    HashVecMap(HashMapVecMap),
+}
+
+pub struct NoOPMapping;
+impl<INDEX, VALUE> BidirectionalMapping<INDEX, VALUE> for NoOPMapping
+where
+    INDEX: Default,
+    VALUE: Default,
+{
+    fn insert_or_get_index(&mut self, _: VALUE) -> INDEX {
+        Default::default()
+    }
+
+    fn get_index(&self, _: &VALUE) -> Option<&INDEX> {
+        Default::default()
+    }
+
+    fn get_value(&mut self, _: INDEX) -> Option<&VALUE> {
+        Default::default()
+    }
+
+    fn len(&self) -> usize {
+        Default::default()
+    }
+}
+
+impl BidirectionalMapping<u32, String> for Mappings {
+    fn insert_or_get_index(&mut self, value: String) -> u32 {
+        match self {
+            Mappings::HashVecMap(hm) => hm.insert_or_get_index(value),
+        }
+    }
+
+    fn get_index(&self, value: &String) -> Option<&u32> {
+        match self {
+            Mappings::HashVecMap(hm) => hm.get_index(value),
+        }
+    }
+
+    fn get_value(&mut self, index: u32) -> Option<&String> {
+        match self {
+            Mappings::HashVecMap(hm) => hm.get_value(index),
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Mappings::HashVecMap(hm) => hm.len(),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct HashMapVecMap {
+    reverse: Vec<String>,
+    s2val: HashMap<String, u32>,
+}
+
+impl BidirectionalMapping<u32, String> for HashMapVecMap {
+    fn insert_or_get_index(&mut self, value: String) -> u32 {
+        *self.s2val.entry(value).or_insert_with_key(|value| {
+            let idx = self.reverse.len() as u32;
+            self.reverse.push(value.clone());
+            idx
+        })
+    }
+    fn get_index(&self, key: &String) -> Option<&u32> {
+        self.s2val.get(key)
+    }
+    fn get_value(&mut self, index: u32) -> Option<&String> {
+        self.reverse.get(index as usize)
+    }
+    fn len(&self) -> usize {
+        self.reverse.len()
+    }
+}

--- a/src/reader/arpa/mod.rs
+++ b/src/reader/arpa/mod.rs
@@ -41,8 +41,7 @@ pub enum ArpaReadError {
 
 pub struct ArpaModel<T>
 where
-    T: NGramProcessor,
-    <T as NGramProcessor>::Output: NGramRep,
+    T: NGramRep,
 {
     pub vocab: Mappings,
     pub sections: ArpaFileSections<T>,
@@ -50,12 +49,11 @@ where
 
 pub struct ArpaFileSections<T>
 where
-    T: NGramProcessor,
-    <T as NGramProcessor>::Output: NGramRep,
+    T: NGramRep,
 {
     pub counts: Counts,
-    pub backoffs: Vec<Vec<ProbBackoffNgram<T::Output>>>,
-    pub no_backoff: Vec<ProbNgram<T::Output>>,
+    pub backoffs: Vec<Vec<ProbBackoffNgram<T>>>,
+    pub no_backoff: Vec<ProbNgram<T>>,
 }
 
 pub trait NGramProcessor {
@@ -172,7 +170,7 @@ where
     /// Consumes the remainder of the reader and parses it according to the count-header of the file
     /// returns a tuple where the first element are the backoff sections in ascending ngram order,
     /// the second element is the highest order section which has no backoff values.
-    pub fn into_arpa_sections(mut self) -> Result<ArpaFileSections<T>, ArpaReadError> {
+    pub fn into_arpa_sections(mut self) -> Result<ArpaFileSections<T::Output>, ArpaReadError> {
         let mut backoffs = vec![];
         while let Some(backoff) = self.next_backoff_section()? {
             backoffs.push(backoff)
@@ -344,7 +342,7 @@ fn matches_ngram_section_header(line: &str, order: NonZeroUsize) -> Result<(), A
 pub fn read_arpa<B, T>(
     buf_read: B,
     ngram_processor: T,
-) -> Result<ArpaFileSections<T>, ArpaReadError>
+) -> Result<ArpaFileSections<T::Output>, ArpaReadError>
 where
     B: BufRead,
     T: NGramProcessor,

--- a/src/reader/arpa/test.rs
+++ b/src/reader/arpa/test.rs
@@ -12,8 +12,8 @@ use crate::{
 use super::{ArpaReadError, ArpaReader, NGram, ProbBackoff, ProbBackoffNgram, ProbNgram};
 
 fn compare_expectation(thing: ProbBackoff, expectation: ProbBackoff) {
-    approx::assert_abs_diff_eq!(thing.backoff, expectation.backoff);
-    approx::assert_abs_diff_eq!(thing.log_prob, expectation.log_prob);
+    assert_abs_diff_eq!(thing.backoff, expectation.backoff);
+    assert_abs_diff_eq!(thing.log_prob, expectation.log_prob);
 }
 
 fn check_probbackoff_for_order<T>(
@@ -48,7 +48,7 @@ where
 
 #[test]
 fn test_reads() {
-    let fd = std::fs::File::open("test_data/arpa/lm_small.arpa").unwrap();
+    let fd = fs::File::open("test_data/arpa/lm_small.arpa").unwrap();
     let br = BufReader::new(fd);
 
     let ArpaFileSections {
@@ -57,6 +57,7 @@ fn test_reads() {
         no_backoff,
     } = read_arpa(br, StringProcessor).unwrap();
     assert_eq!(backoffs.len(), 2);
+
     let uni_expect = get_unigrams();
     check_probbackoff_for_order(&backoffs[0], uni_expect);
     let bi_expect = get_bigrams();

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -1,3 +1,5 @@
+use std::hash::Hash;
+
 pub mod arpa;
 
 #[derive(Debug, Clone)]
@@ -6,17 +8,40 @@ pub struct ProbBackoff {
     pub backoff: f32,
 }
 
+pub trait NGramRep: std::fmt::Debug + Clone + PartialEq + Eq + Hash {}
+
+impl NGramRep for String {}
+impl NGramRep for Vec<usize> {}
+impl NGramRep for Vec<u32> {}
+impl NGramRep for Vec<u16> {}
+impl NGramRep for Vec<u8> {}
+impl NGramRep for () {}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NGram(String); // TODO: this sensible?
+pub struct NGram<T>(T)
+where
+    T: NGramRep; // TODO: this sensible?
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Sequence {
+    String(String),
+    Ints(Vec<u32>),
+}
 
 #[derive(Debug, Clone)]
-pub struct ProbBackoffNgram {
-    pub ngram: NGram,
+pub struct ProbBackoffNgram<T>
+where
+    T: NGramRep,
+{
+    pub ngram: NGram<T>,
     pub prob_backoff: ProbBackoff,
 }
 
 #[derive(Debug, Clone)]
-pub struct ProbNgram {
-    pub ngram: NGram,
+pub struct ProbNgram<T>
+where
+    T: NGramRep,
+{
+    pub ngram: NGram<T>,
     pub prob: f32,
 }


### PR DESCRIPTION
configurable vocab mapping

currently supports `Vec<u32>`, `String`, and `()`